### PR TITLE
Session creation and Achievement retrieval modified for more consistent testing

### DIFF
--- a/lib/routes/achievements.ts
+++ b/lib/routes/achievements.ts
@@ -1,23 +1,28 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { Achievement } from '../models/Achievement';
+import { IAchievementDocument } from '../interfaces/IAchievementDocument';
 
 export default Router()
   .get('/achievements/new', ({ query }: Request, res: Response, next: NextFunction) => {
     const { userId } = query;
+    let newAchievements: IAchievementDocument[] = [];
     Achievement
       .find({ userId, delivered: false })
       .sort({ created: 'desc' })
-      .then(achieves => res.send(achieves))
+      .then((achieves: IAchievementDocument[]) => newAchievements = achieves)
       .then(() => Achievement.markAsDelivered(userId))
+      .then(() => res.send(newAchievements))
       .catch(next);
   })
 
   .get('/achievements', ({ query }: Request, res: Response, next: NextFunction) => {
     const { userId } = query;
+    let allAchievements: IAchievementDocument[] = [];
     Achievement
       .find({ userId })
       .sort({ created: 'desc' })
-      .then(achieves => res.send(achieves))
+      .then((achieves: IAchievementDocument[]) => allAchievements = achieves)
       .then(() => Achievement.markAsDelivered(userId))
+      .then(() => res.send(allAchievements))
       .catch(next);
   });

--- a/lib/routes/sessions.ts
+++ b/lib/routes/sessions.ts
@@ -15,10 +15,12 @@ export default Router()
 
   .post('/sessions', (req: Request, res: Response, next: NextFunction) => {
     const { start, duration, userId, moods } = req.body;
+    let createdSession: ISessionDocument = null;
     Session
       .create({ start, duration, userId, moods })
-      .then((session: ISessionDocument) => res.send(session))
+      .then((session: ISessionDocument) => createdSession = session)
       .then(() => User.schema.statics.updateStreak(userId, start))
       .then(user => Achievement.schema.statics.updateUser(user))
+      .then(() => res.send(createdSession))
       .catch(next);
   });


### PR DESCRIPTION
prevent potential race condition
With the previous implementation, tests failed occasionally when mongoDB timing was slower than immediate - especially for marking achievements as "delivered" which was being done **after** the response was sent. 
In the new implementation, achievements are marked as "delivered" in the DB before returning the response.